### PR TITLE
Docs fix readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ build
 CMakeFiles
 dist
 
+.idea
+
 # CMake
 Makefile
 cmake_install.cmake

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 1. Run `git clone https://github.com/LeonMrBonnie/altv-module-boilerplate.git` to clone the repository
 2. Navigate to the folder with `cd altv-module-boilerplate`
 3. Run `git submodule init` to initialize the submodules
-4. Then run `git submodule update` to fetch the submodules
+4. Then run `git submodule update --init --recursive` to fetch the submodules
 5. Run the `tools/build.bat` *(Windows)* or the `tools/build.sh` *(Linux)* to build the project using CMake
 6. The built project `.dll` / `.so` can now be found in the `dist` directory
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@
 
 1. Run `git clone https://github.com/LeonMrBonnie/altv-module-boilerplate.git` to clone the repository
 2. Navigate to the folder with `cd altv-module-boilerplate`
-3. Run `git submodule init` to initialize the submodules
-4. Then run `git submodule update --init --recursive` to fetch the submodules
-5. Run the `tools/build.bat` *(Windows)* or the `tools/build.sh` *(Linux)* to build the project using CMake
-6. The built project `.dll` / `.so` can now be found in the `dist` directory
+3. Run the `tools/update-sdk.bat` *(Windows)* or `tools/update-sdk.sh` *(Linux)* to make sure you have the last version of the SDK.
+4. Run `git submodule init` to initialize the submodules
+5. Then run `git submodule update --init --recursive` to fetch the submodules recursively.
+6. Run the `tools/build.bat` *(Windows)* or the `tools/build.sh` *(Linux)* to build the project using CMake
+7. The built project `.dll` / `.so` can now be found in the `dist` directory
 
 If any errors persist, make sure to follow steps closely.
 

--- a/src/resource.cpp
+++ b/src/resource.cpp
@@ -11,7 +11,7 @@
 bool BoilerplateResource::Start()
 {
     // Load file
-    auto src = ReadFile(resource->GetMain().ToString());
+    auto src = ReadFile(resource->GetMain());
     if(src.empty())
     {
         Log::Error << "Failed to read resource main file" << Log::Endl;

--- a/src/resource.cpp
+++ b/src/resource.cpp
@@ -11,7 +11,7 @@
 bool BoilerplateResource::Start()
 {
     // Load file
-    auto src = ReadFile(resource->GetMain());
+    auto src = ReadFile(resource->GetMain().ToString());
     if(src.empty())
     {
         Log::Error << "Failed to read resource main file" << Log::Endl;


### PR DESCRIPTION
Changing readme:
 - Without recursive option the submodule from the SDK alt-config won't be retrieved resulting in build failure.
 - resource->GetMain() returns a StringView which is not implicitly convertible to a std::string.